### PR TITLE
Fix schema to properly reference binary inputs

### DIFF
--- a/general/b.json
+++ b/general/b.json
@@ -3,8 +3,6 @@
   "type": "array",
   "description": "Invoke setup mode\nInputs that can be used to enter setup mode\n\nhttps://github.com/RavenSystem/esp-homekit-devices/wiki/General-Configuration#Buttons-to-invoke-setup-mode",
   "items": {
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {}
+    "$ref": "../binary-input.json"
   }
 }


### PR DESCRIPTION
This fixes the issue I raised yesterday.   Several sample definitions now validate. 

I will attempt to validate ALL definitions in the device database to confirm the schemas and will attempt to fix any problems I find.